### PR TITLE
Corrected type casting in time/parser.hpp

### DIFF
--- a/include/boost/astronomy/time/parser.hpp
+++ b/include/boost/astronomy/time/parser.hpp
@@ -29,9 +29,9 @@ public:
       dh = d;
 
       time = dh;
-      hours = (int)time;
+      hours = (long int)time;
       minutesRemainder = (time - hours) * 60;
-      minutes = (int)minutesRemainder;
+      minutes = (long int)minutesRemainder;
       secondsRemainder = (minutesRemainder - minutes) * 60;
       seconds = secondsRemainder;
     }


### PR DESCRIPTION
Fixed time quantities being cast as int instead of long int

closes #173

<!-- Pull Requests MUST come from topic branch based on develop, and NEVER on `master) --->

### Description

<!-- What does this pull request do? -->

### References

<!-- Any links related to this PR: issues, other PRs, mailing list threads, StackOverflow questions, etc. -->

### Tasklist

<!-- Add YOUR OWN TASK(s), especially if your PR is a work in progress -->

- [ ] Add test case(s)
- [ ] Ensure all CI builds pass
- [ ] Review and approve
